### PR TITLE
[Chore] 400 에러핸들링 추가 및 토큰 만료 시 에러 핸들링 개선

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/auth/service/jwt/JwtAuthenticationFilter.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/service/jwt/JwtAuthenticationFilter.java
@@ -1,12 +1,14 @@
 package com.efub.mavve.auth.service.jwt;
 
 import com.efub.mavve.auth.domain.User;
+import com.efub.mavve.global.config.CustomAuthenticationEntryPoint;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -17,27 +19,32 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtResolver jwtResolver;
     private final UserDetailsService userDetailsService;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String bearerToken = request.getHeader("Authorization");
+        try {
+            String bearerToken = request.getHeader("Authorization");
 
-        if(bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            bearerToken = bearerToken.substring(7);
-            String userId = jwtResolver.resolveAccessToken(bearerToken);
-            CustomUserDetails userDetails = userDetailsService.loadUserByUsername(userId);
-            User user = userDetails.getUser();
+            if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+                bearerToken = bearerToken.substring(7);
+                String userId = jwtResolver.resolveAccessToken(bearerToken);
+                CustomUserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+                User user = userDetails.getUser();
 
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    user, null, userDetails.getAuthorities());
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        user, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
 
 
+            }
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException exception){
+            authenticationEntryPoint.commence(request, response, exception);
         }
-        filterChain.doFilter(request, response);
     }
 
 

--- a/mavve/src/main/java/com/efub/mavve/auth/service/jwt/JwtResolver.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/service/jwt/JwtResolver.java
@@ -1,9 +1,11 @@
 package com.efub.mavve.auth.service.jwt;
 
+import com.efub.mavve.global.exception.CustomAuthenticationException;
 import com.efub.mavve.global.exception.ExceptionCode;
 import com.efub.mavve.global.exception.MavveException;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -31,10 +33,10 @@ public class JwtResolver {
 
             Long userId = Long.parseLong(claims.getSubject());
             return Long.toString(userId);
-        }catch (ExpiredJwtException exception){
-            throw new MavveException(ExceptionCode.AUTH_TOKEN_EXPIRED);
-        }catch (JwtException exception){
-            throw new MavveException(ExceptionCode.AUTH_TOKEN_INVALID);
+        }catch (ExpiredJwtException exception) {
+            throw new CustomAuthenticationException(ExceptionCode.AUTH_TOKEN_EXPIRED, ExceptionCode.AUTH_TOKEN_EXPIRED.getMessage(), exception);
+        } catch (JwtException exception) {
+            throw new CustomAuthenticationException(ExceptionCode.AUTH_TOKEN_INVALID, ExceptionCode.AUTH_TOKEN_INVALID.getMessage(), exception);
         }
     }
 

--- a/mavve/src/main/java/com/efub/mavve/global/config/CustomAuthenticationEntryPoint.java
+++ b/mavve/src/main/java/com/efub/mavve/global/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package com.efub.mavve.global.config;
+
+import com.efub.mavve.global.exception.CustomAuthenticationException;
+import com.efub.mavve.global.exception.ExceptionCode;
+import com.efub.mavve.global.exception.dto.ExceptionResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        ExceptionCode exceptionCode = ExceptionCode.AUTH_TOKEN_INVALID; // 기본값
+
+        if (authException instanceof CustomAuthenticationException customEx) {
+            exceptionCode = customEx.getExceptionCode();
+        }
+
+        ExceptionResponse responseBody = new ExceptionResponse(
+                HttpStatus.UNAUTHORIZED.value(),
+                exceptionCode.name(),
+                exceptionCode.getMessage(),
+                request.getRequestURI(),
+                ZonedDateTime.now()
+        );
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+        objectMapper.writeValue(response.getWriter(), responseBody);
+    }
+
+}

--- a/mavve/src/main/java/com/efub/mavve/global/config/SecurityConfig.java
+++ b/mavve/src/main/java/com/efub/mavve/global/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtResolver jwtResolver, UserDetailsService userDetailsService) throws Exception {
         http
@@ -32,7 +33,7 @@ public class SecurityConfig {
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtResolver, userDetailsService),
+                        new JwtAuthenticationFilter(jwtResolver, userDetailsService, customAuthenticationEntryPoint),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .csrf(AbstractHttpConfigurer::disable);

--- a/mavve/src/main/java/com/efub/mavve/global/exception/CustomAuthenticationException.java
+++ b/mavve/src/main/java/com/efub/mavve/global/exception/CustomAuthenticationException.java
@@ -1,0 +1,17 @@
+package com.efub.mavve.global.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class CustomAuthenticationException extends AuthenticationException {
+    private final ExceptionCode exceptionCode;
+
+    public CustomAuthenticationException(ExceptionCode code, String message, Throwable cause) {
+        super(message, cause);
+        this.exceptionCode = code;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}
+

--- a/mavve/src/main/java/com/efub/mavve/global/handler/GlobalErrorHandler.java
+++ b/mavve/src/main/java/com/efub/mavve/global/handler/GlobalErrorHandler.java
@@ -6,6 +6,8 @@ import com.efub.mavve.global.exception.dto.ExceptionResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -24,6 +26,22 @@ public class GlobalErrorHandler {
         );
         return ResponseEntity.status(e.getHttpStatusCode())
                 .body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String errorMessage = "유효하지 않은 입력입니다.";
+        FieldError fieldError = e.getFieldError();
+        if(fieldError != null) {
+            errorMessage = fieldError.getDefaultMessage();
+        }
+        ExceptionResponse response = new ExceptionResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                ExceptionCode.ILLEGAL_ARGUMENT.name(),
+                errorMessage,
+                request.getRequestURI(), ZonedDateTime.now()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
     @ExceptionHandler(RuntimeException.class)


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요.
- 누락된 파라미터가 존재 시 전역적으로 400 에러로 처리하는 부분 추가
- 만료된 토큰일 시에 401 에러 보내도록 securityConfig 관련 수정

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [X] Postman 테스트
- [ ] 단위 테스트 수행

## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- #3
