### PR TITLE
[Feat] 유저프로필 가져오기 및 수정 api

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/auth/controller/AuthController.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/controller/AuthController.java
@@ -1,12 +1,16 @@
 package com.efub.mavve.auth.controller;
 
+import com.efub.mavve.auth.domain.User;
 import com.efub.mavve.auth.dto.request.SpotifyCodeRequest;
+import com.efub.mavve.auth.dto.request.UserInfoRequest;
 import com.efub.mavve.auth.dto.response.SpotifyRedirctUri;
+import com.efub.mavve.auth.dto.response.UserInfoResponse;
 import com.efub.mavve.auth.service.AuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -31,5 +35,16 @@ public class AuthController {
     public ResponseEntity<Void> reissue(@CookieValue(value = "refresh_token", required = false) String refreshToken, HttpServletResponse response) {
         authService.reissue(refreshToken, response);
         return ResponseEntity.created(null).build();
+    }
+
+    @GetMapping("/users/me")
+    public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(authService.getUserInfo(user));
+    }
+
+    @PatchMapping("/users/me")
+    public ResponseEntity<UserInfoResponse> updateUserInfo(@AuthenticationPrincipal User user,
+                                                           @Valid @RequestBody UserInfoRequest userInfoRequest){
+        return ResponseEntity.ok(authService.updateUserInfo(user, userInfoRequest));
     }
 }

--- a/mavve/src/main/java/com/efub/mavve/auth/domain/User.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/domain/User.java
@@ -38,4 +38,9 @@ public class User {
                 .spotifyUserId(spotifyUserId)
                 .build();
     }
+
+    public void updateProfile(String username, String profileImageUrl){
+        this.username = username;
+        this.userImageUrl = profileImageUrl;
+    }
 }

--- a/mavve/src/main/java/com/efub/mavve/auth/dto/request/UserInfoRequest.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/dto/request/UserInfoRequest.java
@@ -1,0 +1,14 @@
+package com.efub.mavve.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserInfoRequest {
+    @NotBlank(message = "닉네임을 입력해야합니다.")
+    private final String nickname;
+    @NotBlank(message = "프로필 이미지를 입력해야합니다.")
+    private final String profile;
+}

--- a/mavve/src/main/java/com/efub/mavve/auth/dto/response/UserInfoResponse.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/dto/response/UserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.efub.mavve.auth.dto.response;
+
+import com.efub.mavve.auth.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class UserInfoResponse {
+    private final String nickname;
+    private final String profile;
+
+    public static UserInfoResponse fromUserEntity(User user){
+        return UserInfoResponse.builder()
+                .nickname(user.getUsername())
+                .profile(user.getUserImageUrl())
+                .build();
+    }
+}

--- a/mavve/src/main/java/com/efub/mavve/auth/service/AuthService.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/service/AuthService.java
@@ -2,8 +2,10 @@ package com.efub.mavve.auth.service;
 
 import com.efub.mavve.auth.domain.User;
 import com.efub.mavve.auth.dto.request.SpotifyCodeRequest;
+import com.efub.mavve.auth.dto.request.UserInfoRequest;
 import com.efub.mavve.auth.dto.response.SpotifyRedirctUri;
 import com.efub.mavve.auth.dto.response.SpotifyUserInfoResponse;
+import com.efub.mavve.auth.dto.response.UserInfoResponse;
 import com.efub.mavve.auth.repository.UserRepository;
 import com.efub.mavve.auth.service.jwt.JwtProvider;
 import com.efub.mavve.auth.service.jwt.JwtResolver;
@@ -50,6 +52,20 @@ public class AuthService {
         }
         // 존재하지 않는 유저이므로 회원가입
         registerKakaoUser(userInfoResponse, response);
+    }
+
+    @Transactional(readOnly = true)
+    public UserInfoResponse getUserInfo(User user) {
+        return UserInfoResponse.fromUserEntity(user);
+    }
+
+    @Transactional
+    public UserInfoResponse updateUserInfo(User user, UserInfoRequest userInfoRequest) {
+        User updateUser = getUserByUserId(user.getUserId());
+        String newUsername = userInfoRequest.getNickname();
+        String newProfileImageUrl = userInfoRequest.getProfile();
+        updateUser.updateProfile(newUsername, newProfileImageUrl);
+        return UserInfoResponse.fromUserEntity(updateUser);
     }
 
     @Transactional

--- a/mavve/src/main/java/com/efub/mavve/songs/controller/SongController.java
+++ b/mavve/src/main/java/com/efub/mavve/songs/controller/SongController.java
@@ -6,10 +6,7 @@ import com.efub.mavve.songs.service.SongService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/songs")


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요.
- `/users/me` - GET : 유저프로필 가져오기 및 수정
- `/users/me` - PATCH : 유저프로필 수정

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [X] Postman 테스트
- [ ] 단위 테스트 수행

## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요. 
### 😅 유저프로필 수정 시, 400 에러 발생
- 막혔다기보다는 너무 황당한 문제긴 하다...
- 자꾸 **프로필사진URL**이 누락되었단느 400에러가 떠서 뭐지 싶었는데 알고보니 Controller에 `@RequestBody` 어노테이션을 붙이지 않아서 발생되는 문제였다... ^^ 바보...같았다 ㅎㅎ
###  😅 `@AuthenticationPrincipal User user`에서 영속성 문제
- Transactional 어노테이션을 사용하고 객체를 update를 하면 당연히 더티체킹을 통해서 save를 하지 않아도 당연히 DB에 수정 사항이 적용될 것이라고 판단했는데 바뀌지 않았다.
- 현재 필터에 CustomUserDetails가 아니라 User 객체로 불러오게 되어 있었는데, 이때 해당되는 User 그 자체를 가져오는 게 아니라 복사본을 가지고 오는 것이라, 해당 객체가 Detached 상태였다.
```
    @Transactional
    public UserInfoResponse updateUserInfo(User user, UserInfoRequest userInfoRequest) {
        User updateUser = getUserByUserId(user.getUserId());
        // (생략)
```
- 위와 같이 userId를 가져오는 방식을 택했다.
  - 어차피 CustomUserDetails로 대신하게 되면 userId를 가져와서 해당 userId로 레포지토리에 정의된 함수로 객체를 불러오는 과정에 필수이기 때문에 거의 똑같다고 생각해서 이렇게 진행하기로 결심했다 ^^

## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- closes #24 
