### PR TITLE
[Feat] 방과 플레이리스트 연결 

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/room/domain/RoomPlaylist.java
+++ b/mavve/src/main/java/com/efub/mavve/room/domain/RoomPlaylist.java
@@ -1,0 +1,31 @@
+package com.efub.mavve.room.domain;
+
+import com.efub.mavve.playlist.domain.Playlist;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomPlaylist {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long playlistRoomId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "playlist_id")
+    private Playlist playlist;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    public static RoomPlaylist create(Playlist playlist, Room room){
+        return RoomPlaylist.builder()
+                .playlist(playlist)
+                .room(room)
+                .build();
+    }
+}

--- a/mavve/src/main/java/com/efub/mavve/room/repository/RoomPlaylistRepository.java
+++ b/mavve/src/main/java/com/efub/mavve/room/repository/RoomPlaylistRepository.java
@@ -1,0 +1,15 @@
+package com.efub.mavve.room.repository;
+
+import com.efub.mavve.playlist.domain.Playlist;
+import com.efub.mavve.room.domain.Room;
+import com.efub.mavve.room.domain.RoomPlaylist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface RoomPlaylistRepository extends JpaRepository<RoomPlaylist, Long> {
+    //@Query("SELECT rp.playlist FROM RoomPlaylist rp WHERE rp.room = :room")
+    List<RoomPlaylist> findByRoom(Room room);
+}

--- a/mavve/src/main/java/com/efub/mavve/room/service/RoomPlaylistService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/RoomPlaylistService.java
@@ -1,0 +1,75 @@
+package com.efub.mavve.room.service;
+
+import com.efub.mavve.global.exception.ExceptionCode;
+import com.efub.mavve.global.exception.MavveException;
+import com.efub.mavve.playlist.domain.Playlist;
+import com.efub.mavve.playlist.dto.summary.PlaylistSummary;
+import com.efub.mavve.playlist.repository.PlaylistRepository;
+import com.efub.mavve.room.domain.Room;
+import com.efub.mavve.room.domain.RoomPlaylist;
+import com.efub.mavve.room.dto.response.RoomListResponse;
+import com.efub.mavve.room.dto.response.RoomResponse;
+import com.efub.mavve.room.repository.RoomPlaylistRepository;
+import com.efub.mavve.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RoomPlaylistService {
+
+    private final PlaylistRepository playlistRepository;
+    private final RoomRepository roomRepository;
+    private final RoomPlaylistRepository roomPlaylistRepository;
+
+    // 방에 플레이리스트 추가
+    @Transactional
+    public void addPlaylistInRoom(Long roomId, Long playlistId){
+        Playlist playlist = getPlaylistOrThrow(playlistId);
+        Room room = roomRepository.findByRoomId(roomId)
+                .orElseThrow(()-> new MavveException(ExceptionCode.ROOM_NOT_FOUND));
+
+        RoomPlaylist roomPlaylist = RoomPlaylist.create(playlist, room);
+        roomPlaylistRepository.save(roomPlaylist);
+    }
+
+    // 방의 플레이리스트 조회
+    @Transactional(readOnly = true)
+    public List<PlaylistSummary> getPlaylistInRoom(Long roomId){
+        Room room = roomRepository.findByRoomId(roomId)
+                .orElseThrow(()-> new MavveException(ExceptionCode.ROOM_NOT_FOUND));
+        List<RoomPlaylist> roomPlaylists = roomPlaylistRepository.findByRoom(room);
+        List<Playlist> playlists = roomPlaylists.stream()
+                .map(RoomPlaylist::getPlaylist)
+                .toList();
+
+//        List<RoomResponse> responseList = roomList.stream()
+//                .map(room -> {
+//                    int likeCount = roomLikeRepository.countByRoom(room);
+//                    return RoomResponse.from(room, likeCount);})
+//                .collect(Collectors.toList());
+//        return RoomListResponse.from(responseList);
+
+        return playlists.stream()
+                .map(PlaylistSummary::from)
+                .collect(Collectors.toList());
+    }
+
+    // 플레이리스트 존재 여부 검사
+    private Playlist getPlaylistOrThrow(Long playlistId) {
+        return playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new MavveException(ExceptionCode.PLAYLIST_NOT_FOUND));
+    }
+
+    // playlistId 조회
+    @Transactional(readOnly = true)
+    public Playlist findByPlaylistId(Long playlistId){
+        return playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new MavveException(ExceptionCode.PLAYLIST_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요. (아래 부분은 지우고 작성)
- [x] 방에 플레이리스트 추가 API
- [x] 방에 추가된 플레이리스트 조회 API

## 🔎 Postman 테스트 내용
- 방에 플레이리스트 추가 
<img width="1380" height="710" alt="image" src="https://github.com/user-attachments/assets/86ed47d3-572b-4efd-b30f-64209ea91534" />

- 방에 추가된 플레이리스트 조회 
<img width="1439" height="926" alt="image" src="https://github.com/user-attachments/assets/2d85260e-0aa6-4d31-baa6-4b2d1c9a97c7" />

## ⚠️ 어려웠던 점과 해결 과정
처음에 방과 연결된 플레이리스트를 조회할 때 @Query("SELECT rp.playlist FROM RoomPlaylist rp WHERE rp.room = :room")로 param을 사용해서 조회함. 그랬더니 중복된 플레이리스트는 뜨지 않는 문제가 발생해서 room으로 RoomPlaylist를 조회하고 RoomPlaylist에서 PlaylistId를 사용해서 중복된 플레이리스트도 모두 반환될 수 있게 함. 


## 🧾 관련 이슈
- closes #54  
