### PR TITLE
[Fix] redis 저장 시 고유 UUID 저장 및 다음 노래 시작시간 전달

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/room/dto/response/RoomEnterResponse.java
+++ b/mavve/src/main/java/com/efub/mavve/room/dto/response/RoomEnterResponse.java
@@ -2,7 +2,7 @@ package com.efub.mavve.room.dto.response;
 
 import com.efub.mavve.room.domain.Room;
 import com.efub.mavve.room.payload.summary.CurrentSongSummary;
-import com.efub.mavve.room.payload.summary.SongSummary;
+import com.efub.mavve.room.payload.summary.SongRedis;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,10 +18,10 @@ public class RoomEnterResponse {
     String createdBy;
     int songCount;
     String totalDuration;
-    List<SongSummary> songs;
+    List<SongRedis> songs;
     CurrentSongSummary currentSong;
 
-    public static RoomEnterResponse from(Room room, List<SongSummary> songList, String duration, CurrentSongSummary currentSong){
+    public static RoomEnterResponse from(Room room, List<SongRedis> songList, String duration, CurrentSongSummary currentSong){
         return RoomEnterResponse.builder()
                 .roomName(room.getRoomName())
                 .createdBy(room.getUser().getUsername())

--- a/mavve/src/main/java/com/efub/mavve/room/payload/response/AddSongResponsePayload.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/response/AddSongResponsePayload.java
@@ -1,6 +1,6 @@
 package com.efub.mavve.room.payload.response;
 
-import com.efub.mavve.room.payload.summary.SongSummary;
+import com.efub.mavve.room.payload.summary.SongRedis;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,9 +11,9 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AddSongResponsePayload {
     MessageType type;
-    SongSummary song;
+    SongRedis song;
 
-    public static AddSongResponsePayload from(SongSummary song) {
+    public static AddSongResponsePayload from(SongRedis song) {
         return AddSongResponsePayload.builder()
                 .type(MessageType.ADD_SONG)
                 .song(song)

--- a/mavve/src/main/java/com/efub/mavve/room/payload/response/NextSongResponsePayload.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/response/NextSongResponsePayload.java
@@ -6,16 +6,20 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NextSongResponsePayload {
     MessageType type;
+    LocalDateTime startTime;
     SongRedis song;
 
-    public static NextSongResponsePayload from(SongRedis song) {
+    public static NextSongResponsePayload from(SongRedis song, LocalDateTime startTime) {
         return NextSongResponsePayload.builder()
                 .type(MessageType.NEXT)
+                .startTime(startTime)
                 .song(song)
                 .build();
     }

--- a/mavve/src/main/java/com/efub/mavve/room/payload/response/NextSongResponsePayload.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/response/NextSongResponsePayload.java
@@ -1,6 +1,6 @@
 package com.efub.mavve.room.payload.response;
 
-import com.efub.mavve.room.payload.summary.SongSummary;
+import com.efub.mavve.room.payload.summary.SongRedis;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,9 +11,9 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NextSongResponsePayload {
     MessageType type;
-    SongSummary song;
+    SongRedis song;
 
-    public static NextSongResponsePayload from(SongSummary song) {
+    public static NextSongResponsePayload from(SongRedis song) {
         return NextSongResponsePayload.builder()
                 .type(MessageType.NEXT)
                 .song(song)

--- a/mavve/src/main/java/com/efub/mavve/room/payload/summary/CurrentSongSummary.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/summary/CurrentSongSummary.java
@@ -11,10 +11,10 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CurrentSongSummary {
-    SongSummary song;
+    SongRedis song;
     LocalDateTime startTime;
 
-    public static CurrentSongSummary from(SongSummary song, LocalDateTime startTime){
+    public static CurrentSongSummary from(SongRedis song, LocalDateTime startTime){
         return CurrentSongSummary.builder()
                 .song(song)
                 .startTime(startTime)

--- a/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongRedis.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongRedis.java
@@ -2,6 +2,8 @@ package com.efub.mavve.room.payload.summary;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -10,7 +12,7 @@ public class SongRedis {
     String songId;
     String spotifyId;
     String title;
-    String artist;
+    List<String> artist;
     String album;
     String coverUrl;
     int duration;

--- a/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongRedis.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongRedis.java
@@ -1,0 +1,17 @@
+package com.efub.mavve.room.payload.summary;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SongRedis {
+    String songId;
+    String spotifyId;
+    String title;
+    String artist;
+    String album;
+    String coverUrl;
+    int duration;
+}

--- a/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongSummary.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongSummary.java
@@ -3,6 +3,8 @@ package com.efub.mavve.room.payload.summary;
 import com.efub.mavve.room.service.redis.RoomSongRedisService;
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -10,7 +12,7 @@ import lombok.*;
 public class SongSummary {
     String spotifyId;
     String title;
-    String artist;
+    List<String> artist;
     String album;
     String coverUrl;
     int duration;

--- a/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongSummary.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongSummary.java
@@ -1,5 +1,6 @@
 package com.efub.mavve.room.payload.summary;
 
+import com.efub.mavve.room.service.redis.RoomSongRedisService;
 import lombok.*;
 
 @Getter
@@ -7,10 +8,22 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
 public class SongSummary {
-    String songId;
+    String spotifyId;
     String title;
     String artist;
     String album;
     String coverUrl;
     int duration;
+
+    public static SongRedis toRedisPOJO(SongSummary songSummary){
+        return SongRedis.builder()
+                .songId(RoomSongRedisService.createUUID())
+                .spotifyId(songSummary.spotifyId)
+                .title(songSummary.title)
+                .artist(songSummary.artist)
+                .album(songSummary.album)
+                .coverUrl(songSummary.coverUrl)
+                .duration(songSummary.duration)
+                .build();
+    }
 }

--- a/mavve/src/main/java/com/efub/mavve/room/service/RoomService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/RoomService.java
@@ -11,16 +11,14 @@ import com.efub.mavve.room.dto.response.RoomEnterResponse;
 import com.efub.mavve.room.dto.response.RoomListResponse;
 import com.efub.mavve.room.dto.response.RoomResponse;
 import com.efub.mavve.room.payload.summary.CurrentSongSummary;
-import com.efub.mavve.room.payload.summary.SongSummary;
+import com.efub.mavve.room.payload.summary.SongRedis;
 import com.efub.mavve.room.repository.RoomRepository;
 import com.efub.mavve.room.service.redis.RoomSongRedisService;
 import com.efub.mavve.room.service.redis.RoomUserRedisService;
 import com.efub.mavve.room.service.websocket.RoomSongWebsocketService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import com.efub.mavve.room.repository.RoomLikeRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -153,7 +151,7 @@ public class RoomService {
     @Transactional(readOnly = true)
     public RoomEnterResponse getRoomEnterInfo(Long roomId) {
         Room room = findByRoomId(roomId);
-        List<SongSummary> songList = roomSongRedisService.getAllSongsInRoom(roomId);
+        List<SongRedis> songList = roomSongRedisService.getAllSongsInRoom(roomId);
         log.info("song count : {}", songList.size());
         String duration = getTotalDurationTime(songList);
 
@@ -162,9 +160,9 @@ public class RoomService {
     }
 
     // 첫 입장자인 경우 처리
-    private CurrentSongSummary handleFirstEnter(Long roomId, List<SongSummary> songList) {
+    private CurrentSongSummary handleFirstEnter(Long roomId, List<SongRedis> songList) {
         if (!roomUserRedisService.hasUsers(roomId)) {
-            SongSummary firstSong = roomSongRedisService.getFirstSongInRoom(roomId);
+            SongRedis firstSong = roomSongRedisService.getFirstSongInRoom(roomId);
             if (firstSong != null) {
                 log.info("first user!!");
                 LocalDateTime startTime = LocalDateTime.now();
@@ -181,9 +179,9 @@ public class RoomService {
     }
 
     // 노래 총 재생시간 String으로 변환
-    private String getTotalDurationTime(List<SongSummary> songs){
+    private String getTotalDurationTime(List<SongRedis> songs){
         int totalSeconds = songs.stream()
-                .mapToInt(SongSummary::getDuration)
+                .mapToInt(SongRedis::getDuration)
                 .sum();
 
         int hours = totalSeconds / 3600;

--- a/mavve/src/main/java/com/efub/mavve/room/service/redis/RoomSongRedisService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/redis/RoomSongRedisService.java
@@ -3,6 +3,7 @@ package com.efub.mavve.room.service.redis;
 import com.efub.mavve.global.exception.ExceptionCode;
 import com.efub.mavve.global.exception.MavveException;
 import com.efub.mavve.room.payload.summary.CurrentSongSummary;
+import com.efub.mavve.room.payload.summary.SongRedis;
 import com.efub.mavve.room.payload.summary.SongSummary;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,10 +21,13 @@ public class RoomSongRedisService {
     private final RedisTemplate<String, Object> objectRedisTemplate;
 
     // 노래 추가
-    public void addSong(Long roomCode, SongSummary song) {
+    public SongRedis addSong(Long roomCode, SongSummary request) {
         try{
             String key = RoomRedisKeyUtils.getSongListKey(roomCode);
+            SongRedis song = SongSummary.toRedisPOJO(request);
             objectRedisTemplate.opsForList().rightPush(key, song); // 리스트 맨 뒤에 추가
+
+            return song;
         } catch (Exception e){
             throw new MavveException(ExceptionCode.REDIS_SAVE_ERROR);
         }
@@ -32,6 +37,9 @@ public class RoomSongRedisService {
     public void addSongs(Long roomCode, List<SongSummary> songList){
         try{
             String key = RoomRedisKeyUtils.getSongListKey(roomCode);
+            List<SongRedis> songs = songList.stream()
+                    .map(SongSummary::toRedisPOJO)
+                    .collect(Collectors.toList());
             objectRedisTemplate.opsForList().rightPush(key, songList.toArray()); // 리스트 맨 뒤에 추가
         } catch (Exception e) {
             throw new MavveException(ExceptionCode.REDIS_SAVE_ERROR);
@@ -39,22 +47,22 @@ public class RoomSongRedisService {
     }
 
     // 처음 노래 조회
-    public SongSummary getFirstSongInRoom(Long roomCode){
+    public SongRedis getFirstSongInRoom(Long roomCode){
         String key = RoomRedisKeyUtils.getSongListKey(roomCode);
-        return (SongSummary) objectRedisTemplate.opsForList().getFirst(key);
+        return (SongRedis) objectRedisTemplate.opsForList().getFirst(key);
     }
 
     // 노래 리스트 전체 조회
-    public List<SongSummary> getAllSongsInRoom(Long roomCode) {
+    public List<SongRedis> getAllSongsInRoom(Long roomCode) {
         String key = RoomRedisKeyUtils.getSongListKey(roomCode);
         List<Object> objectList = objectRedisTemplate.opsForList().range(key, 0, -1);
 
         if(objectList == null) return Collections.emptyList();
 
-        List<SongSummary> result = new ArrayList<>();
+        List<SongRedis> result = new ArrayList<>();
         for (Object item : objectList) {
-            if (item instanceof SongSummary) {
-                result.add((SongSummary) item);
+            if (item instanceof SongRedis) {
+                result.add((SongRedis) item);
             } else {
                 throw new MavveException(ExceptionCode.REDIS_DESERIALIZATION_ERROR);
             }
@@ -66,11 +74,11 @@ public class RoomSongRedisService {
     public void deleteSongs(Long roomCode, List<String> songIdsToRemove) {
         try{
             String key = RoomRedisKeyUtils.getSongListKey(roomCode);
-            List<SongSummary> songsInRoom = getAllSongsInRoom(roomCode);
+            List<SongRedis> songsInRoom = getAllSongsInRoom(roomCode);
 
-            for(SongSummary songSummary: songsInRoom){
-                if(songIdsToRemove.contains(songSummary.getSongId())){
-                    objectRedisTemplate.opsForList().remove(key, 1, songSummary);   //1개 삭제
+            for(SongRedis song : songsInRoom){
+                if(songIdsToRemove.contains(song.getSongId())){
+                    objectRedisTemplate.opsForList().remove(key, 1, song);   //1개 삭제
                 }
             }
         } catch (Exception e){
@@ -79,8 +87,8 @@ public class RoomSongRedisService {
     }
 
     // 다음 노래 찾기
-    public SongSummary getNextSong(Long roomCode, SongSummary currentSong){
-        List<SongSummary> songsInRoom = getAllSongsInRoom(roomCode);
+    public SongRedis getNextSong(Long roomCode, SongRedis currentSong){
+        List<SongRedis> songsInRoom = getAllSongsInRoom(roomCode);
 
         // NOTE: 에러처리가 아니라 song에 null값 담아서 보낼지 추가 고민
         if (songsInRoom.isEmpty()) {
@@ -96,7 +104,7 @@ public class RoomSongRedisService {
     }
 
     // 현재 재생되고 있는 노래 저장 (기존 것 삭제)
-    public void addCurrentSong(Long roomCode, SongSummary song, LocalDateTime startTime){
+    public void addCurrentSong(Long roomCode, SongRedis song, LocalDateTime startTime){
         try{
             String key = RoomRedisKeyUtils.getCurrentSongKey(roomCode);
             objectRedisTemplate.delete(key);    // 이전 노래 map 삭제
@@ -114,10 +122,15 @@ public class RoomSongRedisService {
     // 현재 재생되고 있는 노래 조회
     public CurrentSongSummary getCurrentSong(Long roomCode){
         String key = RoomRedisKeyUtils.getCurrentSongKey(roomCode);
-        SongSummary song = (SongSummary) objectRedisTemplate.opsForHash().get(key, "song");
+        SongRedis song = (SongRedis) objectRedisTemplate.opsForHash().get(key, "song");
         LocalDateTime startTime = (LocalDateTime) objectRedisTemplate.opsForHash().get(key, "startTime");
 
         return CurrentSongSummary.from(song, startTime);
+    }
+
+    // 노래 id용 UUID값 생성
+    public static String createUUID(){
+        return UUID.randomUUID().toString();
     }
 
 }

--- a/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
@@ -52,15 +52,18 @@ public class RoomSongWebsocketService {
     // 다음 노래 예약 스케쥴링
     public void scheduleNextSong(Long roomCode, SongSummary currentSong){
         LocalDateTime nextSongStartTime = LocalDateTime.now().plusSeconds(currentSong.getDuration());
-        SongSummary nextSong = songRedisService.getNextSong(roomCode, currentSong);
         Instant scheduleTime = nextSongStartTime
                 .plusSeconds(BROADCAST_DELAY_SECONDS) // 전송 시간 고려해 1초 더 지연
                 .atZone(ZoneId.systemDefault())
                 .toInstant();
 
-        //TODO: 다음노래 예약해놓았는데, 해당 노래 삭제한 경우 다음 노래 변환 로직 추가
-        //TODO: 사용자가 있는 지 확인하고 스케쥴링
         taskScheduler.schedule(() -> {
+            // 방에 사용자 있는지 확인하고 스케쥴링
+            if(!userRedisService.hasUsers(roomCode)){
+                log.info("no user! stop scheduling");
+                return;
+            }
+            SongSummary nextSong = songRedisService.getNextSong(roomCode, currentSong);
             broadcastNextSong(roomCode, nextSong, nextSongStartTime);
         }, scheduleTime);
         log.info("next song schedule!");

--- a/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
@@ -73,7 +73,7 @@ public class RoomSongWebsocketService {
     private void broadcastNextSong(Long roomCode, SongRedis nextSong, LocalDateTime startTime){
         songRedisService.addCurrentSong(roomCode, nextSong, startTime);
         log.info("next song!");
-        messagingTemplate.convertAndSend("/topic/rooms/" + roomCode + "/songs", NextSongResponsePayload.from(nextSong));
+        messagingTemplate.convertAndSend("/topic/rooms/" + roomCode + "/songs", NextSongResponsePayload.from(nextSong, startTime));
         scheduleNextSong(roomCode, nextSong);   // 다음 노래 스케쥴링
     }
 

--- a/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
@@ -8,7 +8,7 @@ import com.efub.mavve.room.payload.request.DeleteSongRequestPayload;
 import com.efub.mavve.room.payload.response.AddSongResponsePayload;
 import com.efub.mavve.room.payload.response.DeleteSongResponsePayload;
 import com.efub.mavve.room.payload.response.NextSongResponsePayload;
-import com.efub.mavve.room.payload.summary.SongSummary;
+import com.efub.mavve.room.payload.summary.SongRedis;
 import com.efub.mavve.room.service.redis.RoomSongRedisService;
 import com.efub.mavve.room.service.redis.RoomUserRedisService;
 import lombok.RequiredArgsConstructor;
@@ -40,8 +40,8 @@ public class RoomSongWebsocketService {
 
     public AddSongResponsePayload addSong(Long roomCode, AddSongRequestPayload request) {
         //TODO: 노래검색 함수 생성 후 검색한 노래로 수정
-        songRedisService.addSong(roomCode, request.getSong());
-        return AddSongResponsePayload.from(request.getSong());
+        SongRedis songAdd = songRedisService.addSong(roomCode, request.getSong());
+        return AddSongResponsePayload.from(songAdd);
     }
 
     public DeleteSongResponsePayload deleteSongs(Long roomCode, DeleteSongRequestPayload request) {
@@ -50,7 +50,7 @@ public class RoomSongWebsocketService {
     }
 
     // 다음 노래 예약 스케쥴링
-    public void scheduleNextSong(Long roomCode, SongSummary currentSong){
+    public void scheduleNextSong(Long roomCode, SongRedis currentSong){
         LocalDateTime nextSongStartTime = LocalDateTime.now().plusSeconds(currentSong.getDuration());
         Instant scheduleTime = nextSongStartTime
                 .plusSeconds(BROADCAST_DELAY_SECONDS) // 전송 시간 고려해 1초 더 지연
@@ -63,17 +63,18 @@ public class RoomSongWebsocketService {
                 log.info("no user! stop scheduling");
                 return;
             }
-            SongSummary nextSong = songRedisService.getNextSong(roomCode, currentSong);
+            SongRedis nextSong = songRedisService.getNextSong(roomCode, currentSong);
             broadcastNextSong(roomCode, nextSong, nextSongStartTime);
         }, scheduleTime);
         log.info("next song schedule!");
     }
 
     // 다음 노래 전환 브로드캐스트
-    private void broadcastNextSong(Long roomCode, SongSummary nextSong, LocalDateTime startTime){
+    private void broadcastNextSong(Long roomCode, SongRedis nextSong, LocalDateTime startTime){
         songRedisService.addCurrentSong(roomCode, nextSong, startTime);
         log.info("next song!");
         messagingTemplate.convertAndSend("/topic/rooms/" + roomCode + "/songs", NextSongResponsePayload.from(nextSong));
+        scheduleNextSong(roomCode, nextSong);   // 다음 노래 스케쥴링
     }
 
     // 노래 정보 받을 주소 구독 -> 사용자 정보 저장


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요. (아래 부분은 지우고 작성)
- redis 저장 시 고유 UUID 저장
- 다음 노래 시작시간 전달
- artist list로 받도록 수정

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [ ] Postman 테스트
- [ ] 단위 테스트 수행
- [x] WebSocket + STOMP 통신 테스트 (https://jiangxy.github.io/websocket-debug-tool/ 이용)

## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요. 
- 같은 노래가 방 안에서 재생되면 기존에 spotifyId로 구분했던 것이 에러가 날 것 같아 각각의 id값으로 UUID를 추가로 저장하도록 수정했습니다.

## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- close #51
- close #53
