### PR TITLE
[Feat] 방 새로 생성 시 노래 목록 redis에 저장

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongRedis.java
+++ b/mavve/src/main/java/com/efub/mavve/room/payload/summary/SongRedis.java
@@ -1,8 +1,12 @@
 package com.efub.mavve.room.payload.summary;
 
+import com.efub.mavve.room.service.redis.RoomSongRedisService;
+import com.efub.mavve.songs.domain.Song;
+import com.efub.mavve.songs.dto.response.spotify.SearchSongResponse;
 import lombok.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -16,4 +20,18 @@ public class SongRedis {
     String album;
     String coverUrl;
     int duration;
+
+    public static SongRedis EntityToRedisPOJO(Song song){
+        return SongRedis.builder()
+                .songId(RoomSongRedisService.createUUID())
+                .spotifyId(song.getSpotifySongId())
+                .title(song.getTitle())
+                .artist(song.getSongArtists().stream()
+                        .map(songArtist -> songArtist.getArtist().getArtistName())
+                        .collect(Collectors.toList()))
+                .album(song.getAlbum())
+                .coverUrl(song.getCoverImageUrl())
+                .duration(song.getDuration())
+                .build();
+    }
 }

--- a/mavve/src/main/java/com/efub/mavve/room/repository/RoomChatRepository.java
+++ b/mavve/src/main/java/com/efub/mavve/room/repository/RoomChatRepository.java
@@ -10,12 +10,13 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface RoomChatRepository extends JpaRepository<RoomChat, Long> {
-    @Query(value =
-            "SELECT new com.efub.mavve.room.dto.summary.ChatSummary(c.roomChatId, c.content, c.createdAt, u.username, u.userImageUrl) " +
-                    "FROM RoomChat c " +
-                    "JOIN c.user u " +
-                    "WHERE c.room.roomId = :roomId " +
-                    "AND (:lastChatId is NULL OR c.roomChatId < :lastChatId) " +
-                    "ORDER BY c.createdAt DESC")
+    @Query("""
+            SELECT new com.efub.mavve.room.dto.summary.ChatSummary(c.roomChatId, c.content, c.createdAt, u.username, u.userImageUrl) 
+            FROM RoomChat c 
+            JOIN c.user u 
+            WHERE c.room.roomId = :roomId 
+            AND (:lastChatId is NULL OR c.roomChatId < :lastChatId) 
+            ORDER BY c.createdAt DESC
+            """)
     List<ChatSummary> findChatsByRoomId(@Param("roomId") Long roomId, @Param("lastChatId") Long lastChatId, Pageable pageable);
 }

--- a/mavve/src/main/java/com/efub/mavve/room/repository/RoomPlaylistRepository.java
+++ b/mavve/src/main/java/com/efub/mavve/room/repository/RoomPlaylistRepository.java
@@ -3,6 +3,7 @@ package com.efub.mavve.room.repository;
 import com.efub.mavve.playlist.domain.Playlist;
 import com.efub.mavve.room.domain.Room;
 import com.efub.mavve.room.domain.RoomPlaylist;
+import com.efub.mavve.songs.domain.Song;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,4 +13,15 @@ import java.util.List;
 public interface RoomPlaylistRepository extends JpaRepository<RoomPlaylist, Long> {
     //@Query("SELECT rp.playlist FROM RoomPlaylist rp WHERE rp.room = :room")
     List<RoomPlaylist> findByRoom(Room room);
+
+    // roomId의 전체 노래 조회
+    @Query("""
+            SELECT s 
+            FROM RoomPlaylist rp
+            JOIN rp.playlist p
+            JOIN p.playlistSongs ps
+            JOIN ps.song s
+            WHERE rp.room.roomId = :roomId
+            """)
+    List<Song> findSongsByRoomId(@Param("roomId") Long roomId);
 }

--- a/mavve/src/main/java/com/efub/mavve/room/service/RoomPlaylistService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/RoomPlaylistService.java
@@ -9,8 +9,11 @@ import com.efub.mavve.room.domain.Room;
 import com.efub.mavve.room.domain.RoomPlaylist;
 import com.efub.mavve.room.dto.response.RoomListResponse;
 import com.efub.mavve.room.dto.response.RoomResponse;
+import com.efub.mavve.room.payload.summary.SongRedis;
 import com.efub.mavve.room.repository.RoomPlaylistRepository;
 import com.efub.mavve.room.repository.RoomRepository;
+import com.efub.mavve.room.service.redis.RoomSongRedisService;
+import com.efub.mavve.songs.domain.Song;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +29,7 @@ public class RoomPlaylistService {
     private final PlaylistRepository playlistRepository;
     private final RoomRepository roomRepository;
     private final RoomPlaylistRepository roomPlaylistRepository;
+    private final RoomSongRedisService roomSongRedisService;
 
     // 방에 플레이리스트 추가
     @Transactional
@@ -71,5 +75,13 @@ public class RoomPlaylistService {
     public Playlist findByPlaylistId(Long playlistId){
         return playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new MavveException(ExceptionCode.PLAYLIST_NOT_FOUND));
+    }
+
+    // 방 새로 생성 시 playlist 내의 노래 목록 redis에 저장
+    @Transactional(readOnly = true)
+    public void addSongsByPlaylist(Long roomCode){
+        List<Song> songRaws = roomPlaylistRepository.findSongsByRoomId(roomCode);
+        List<SongRedis> songs = songRaws.stream().map(SongRedis::EntityToRedisPOJO).collect(Collectors.toList());
+        roomSongRedisService.addSongs(roomCode, songs);
     }
 }

--- a/mavve/src/main/java/com/efub/mavve/room/service/RoomService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/RoomService.java
@@ -34,6 +34,7 @@ public class RoomService {
     private final RoomSongRedisService roomSongRedisService;
     private final RoomUserRedisService roomUserRedisService;
     private final RoomSongWebsocketService roomSongWebsocketService;
+    private final RoomPlaylistService roomPlaylistService;
     private final RoomLikeRepository roomLikeRepository;
 
     // 방 생성
@@ -151,17 +152,23 @@ public class RoomService {
     @Transactional(readOnly = true)
     public RoomEnterResponse getRoomEnterInfo(Long roomId) {
         Room room = findByRoomId(roomId);
+        CurrentSongSummary currentSong = handleFirstEnter(roomId);
+
         List<SongRedis> songList = roomSongRedisService.getAllSongsInRoom(roomId);
         log.info("song count : {}", songList.size());
         String duration = getTotalDurationTime(songList);
-
-        CurrentSongSummary currentSong = handleFirstEnter(roomId, songList);
         return RoomEnterResponse.from(room, songList, duration, currentSong);
     }
 
     // 첫 입장자인 경우 처리
-    private CurrentSongSummary handleFirstEnter(Long roomId, List<SongRedis> songList) {
+    private CurrentSongSummary handleFirstEnter(Long roomId) {
         if (!roomUserRedisService.hasUsers(roomId)) {
+            // 방 생성된 뒤 플레이리스트의 노래들 redis에 저장
+            if(!roomSongRedisService.hasSongs(roomId)){
+                roomPlaylistService.addSongsByPlaylist(roomId);
+            }
+
+            // 첫 번째 노래 재생 시작
             SongRedis firstSong = roomSongRedisService.getFirstSongInRoom(roomId);
             if (firstSong != null) {
                 log.info("first user!!");

--- a/mavve/src/main/java/com/efub/mavve/room/service/RoomService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/RoomService.java
@@ -187,10 +187,11 @@ public class RoomService {
 
     // 노래 총 재생시간 String으로 변환
     private String getTotalDurationTime(List<SongRedis> songs){
-        int totalSeconds = songs.stream()
+        int totalMillis = songs.stream()
                 .mapToInt(SongRedis::getDuration)
                 .sum();
-
+        int totalSeconds = totalMillis / 1000;
+        
         int hours = totalSeconds / 3600;
         int minutes = (totalSeconds % 3600) / 60;
         int seconds = totalSeconds % 60;

--- a/mavve/src/main/java/com/efub/mavve/room/service/redis/RoomSongRedisService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/redis/RoomSongRedisService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -34,13 +33,12 @@ public class RoomSongRedisService {
     }
 
     // 노래 리스트 추가
-    public void addSongs(Long roomCode, List<SongSummary> songList){
-        try{
+    public void addSongs(Long roomCode, List<SongRedis> songList){
+        try {
             String key = RoomRedisKeyUtils.getSongListKey(roomCode);
-            List<SongRedis> songs = songList.stream()
-                    .map(SongSummary::toRedisPOJO)
-                    .collect(Collectors.toList());
-            objectRedisTemplate.opsForList().rightPush(key, songList.toArray()); // 리스트 맨 뒤에 추가
+            for (SongRedis song : songList) {
+                objectRedisTemplate.opsForList().rightPush(key, song);
+            }
         } catch (Exception e) {
             throw new MavveException(ExceptionCode.REDIS_SAVE_ERROR);
         }
@@ -126,6 +124,15 @@ public class RoomSongRedisService {
         LocalDateTime startTime = (LocalDateTime) objectRedisTemplate.opsForHash().get(key, "startTime");
 
         return CurrentSongSummary.from(song, startTime);
+    }
+    
+    // 현재 노래 리스트 있는지 확인
+    public boolean hasSongs(Long roomCode){
+        String key = RoomRedisKeyUtils.getSongListKey(roomCode);
+        Long songCount = objectRedisTemplate.opsForList().size(key);
+        log.info("no song in redis");
+
+        return !(songCount == 0 || songCount == null);
     }
 
     // 노래 id용 UUID값 생성

--- a/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
@@ -21,6 +21,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -50,9 +51,10 @@ public class RoomSongWebsocketService {
 
     // 다음 노래 예약 스케쥴링
     public void scheduleNextSong(Long roomCode, SongRedis currentSong){
-        LocalDateTime nextSongStartTime = LocalDateTime.now().plusSeconds(currentSong.getDuration());
+        LocalDateTime nextSongStartTime = LocalDateTime.now()
+                .plus(Duration.ofMillis(currentSong.getDuration()))
+                .plusSeconds(BROADCAST_DELAY_SECONDS); // 전송 시간 고려해 1초 더 지연
         Instant scheduleTime = nextSongStartTime
-                .plusSeconds(BROADCAST_DELAY_SECONDS) // 전송 시간 고려해 1초 더 지연
                 .atZone(ZoneId.systemDefault())
                 .toInstant();
 

--- a/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
@@ -39,7 +39,6 @@ public class RoomSongWebsocketService {
     private static final int BROADCAST_DELAY_SECONDS = 1;
 
     public AddSongResponsePayload addSong(Long roomCode, AddSongRequestPayload request) {
-        //TODO: 노래검색 함수 생성 후 검색한 노래로 수정
         SongRedis songAdd = songRedisService.addSong(roomCode, request.getSong());
         return AddSongResponsePayload.from(songAdd);
     }


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요. 
- 방 새로 생성 시 노래 목록 redis에 저장하도록 로직 추가
- 초단위가 아닌 ms 단위의 duration으로 노래 예약

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행

## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요. 
- 노래 리스트를 불러오는 과정에서 `방 -> 방에 연결되어있는 플레이리스트 목록-> 플레이리스트 -> 플레이리스트에 연결되어있는 노래리스트 -> 노래 정보` 이런 식으로...... 해당 방의 노래 정보를 처음 저장할 때 찾아가야할 뎁스가 너무 깊어서 엄청난 n+1을 겪을 것 같아.. jpql로 짰습니다
```
SELECT s 
FROM RoomPlaylist rp
JOIN rp.playlist p
JOIN p.playlistSongs ps
JOIN ps.song s
WHERE rp.room.roomId = :roomId
```
artist를 불러올 때 아직 n+1이 발생하는 것 같아서..
지난번처럼 아예 select를 dto로 묶어서 받아버리면 편할 것 같긴한데 song을 받아오고 redis에 저장하기 전에 각각에 UUID를 부여한 후에 redis에 저장해야해서 (노래 중복 가능성 때문에) 우선은 저렇게 구현하고 더 나은 방식이 있는지는 계속 고민해보겠습니다 🥹

## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- close #46 
- close #63
