### PR TITLE
[Fix] room 생성 API 에러 수정 #10

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/global/convertor/AttributeConverter.java
+++ b/mavve/src/main/java/com/efub/mavve/global/convertor/AttributeConverter.java
@@ -3,4 +3,5 @@ package com.efub.mavve.global.convertor;
 public interface AttributeConverter<X, Y> {
     Y convertToDatabaseColumn(X var1);
     X convertToEntityAttribute(Y var1);
+
 }

--- a/mavve/src/main/java/com/efub/mavve/global/convertor/AttributeConverter.java
+++ b/mavve/src/main/java/com/efub/mavve/global/convertor/AttributeConverter.java
@@ -1,0 +1,6 @@
+package com.efub.mavve.global.convertor;
+
+public interface AttributeConverter<X, Y> {
+    Y convertToDatabaseColumn(X var1);
+    X convertToEntityAttribute(Y var1);
+}

--- a/mavve/src/main/java/com/efub/mavve/global/convertor/StringListConverter.java
+++ b/mavve/src/main/java/com/efub/mavve/global/convertor/StringListConverter.java
@@ -1,0 +1,32 @@
+package com.efub.mavve.global.convertor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> entityData) {
+        try {
+            return mapper.writeValueAsString(entityData);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, new TypeReference<List<String>>() {});
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/mavve/src/main/java/com/efub/mavve/room/domain/Room.java
+++ b/mavve/src/main/java/com/efub/mavve/room/domain/Room.java
@@ -1,6 +1,7 @@
 package com.efub.mavve.room.domain;
 
 import com.efub.mavve.auth.domain.User;
+import com.efub.mavve.global.convertor.StringListConverter;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,7 +34,8 @@ public class Room {
     @Column(nullable = false)
     private Long viewCount;
 
-    @Column
+    @Column(columnDefinition = "TEXT")
+    @Convert(converter = StringListConverter.class)
     private List<String> tag;
 
     @Column(nullable = false)


### PR DESCRIPTION
## ✅ 요약
- Room 생성 API 에러 수정 


## 🔎 Postman 테스트 내용
- [x] Postman 테스트
<img width="1842" height="923" alt="image" src="https://github.com/user-attachments/assets/ef37c1f2-f079-4997-b95c-60242928625a" />


## ⚠️ 어려웠던 점과 해결 과정
백엔드 포스트맨 테스트에서는 201 created가 나왔으나, 프론트엔드에서는 Axios 500 에러가 발생함.
→  List<String> tag를 입력받는 과정에서 태그 리스트를 문자열로 변환하지 않고, 이를 BLOB 형태로 DB에 저장하려고 해서 생긴 문제
@Converter를 이용해서 DB에 저장할때 TEXT 형식으로 저장하고 다시 조회할 때는 List로 변환되도록 수정 

  
## ⚠️ 참고 사항 및 주의할 점
참고 블로그
- https://velog.io/@nick6253/MySQL-%EB%8D%B0%EC%9D%B4%ED%84%B0%EB%A1%9C-List-%EB%84%A3%EA%B8%B0AttributeConverter
- https://www.baeldung.com/java-jpa-persist-string-list?utm_source=chatgpt.com


## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- closes #10 
