### PR TITLE
[Refactor] spotify token reissue

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/auth/dto/response/SpotifyReissueResponse.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/dto/response/SpotifyReissueResponse.java
@@ -1,0 +1,15 @@
+package com.efub.mavve.auth.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public class SpotifyReissueResponse {
+   String access_token;
+   String token_type;
+   int expires_in;
+   String refresh_token;
+   String scope;
+}

--- a/mavve/src/main/java/com/efub/mavve/auth/service/oauth/OauthClient.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/service/oauth/OauthClient.java
@@ -43,4 +43,16 @@ public class OauthClient {
     public String getRedirectUri(){
         return oauthProperties.redirectToSpotify();
     }
+
+    public SpotifyReissueResponse getReissueResponse(String refreshToken){
+        String reissueRequestUri = oauthProperties.getReissueUri();
+        MultiValueMap<String, String> reissueRequestBody = oauthProperties.createReissueRequestBodyInSpotify(refreshToken);
+            SpotifyReissueResponse s = restClient.post()
+                    .uri(reissueRequestUri)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(reissueRequestBody)
+                    .retrieve()
+                    .body(SpotifyReissueResponse.class);
+            return s;
+     }
 }

--- a/mavve/src/main/java/com/efub/mavve/auth/service/oauth/OauthProperties.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/service/oauth/OauthProperties.java
@@ -17,6 +17,8 @@ public class OauthProperties {
     private final String tokenRequestUri;
     @Getter
     private final String userInfoUri;
+    @Getter
+    private final String reissueUri;
     private final String redirectUri;
     private final String authorizeUri;
     private final String clientId;
@@ -28,13 +30,15 @@ public class OauthProperties {
             @Value("${spotify.client-id}") String clientId,
             @Value("${spotify.redirect-uri}") String redirectUri,
             @Value("${spotify.auth-uri}") String authorizeUri,
-            @Value("${spotify.client-secret}") String clientSecret) {
+            @Value("${spotify.client-secret}") String clientSecret,
+            @Value("${spotify.reissue-uri}") String reissueUri) {
         this.tokenRequestUri = tokenRequestUri;
         this.userInfoUri = userInfoUri;
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.authorizeUri = authorizeUri;
         this.clientSecret = clientSecret;
+        this.reissueUri = reissueUri;
     }
 
     public String redirectToSpotify() {

--- a/mavve/src/main/java/com/efub/mavve/global/exception/ClientExceptionCode.java
+++ b/mavve/src/main/java/com/efub/mavve/global/exception/ClientExceptionCode.java
@@ -36,4 +36,6 @@ public enum ClientExceptionCode {
     REDIS_DELETE_ERROR,
     REDIS_DESERIALIZATION_ERROR,
     NO_SESSION_ID,
+
+    SPOTIFY_REISSUE_ERROR,
 }

--- a/mavve/src/main/java/com/efub/mavve/global/exception/ExceptionCode.java
+++ b/mavve/src/main/java/com/efub/mavve/global/exception/ExceptionCode.java
@@ -55,7 +55,10 @@ public enum ExceptionCode {
     NO_SESSION_ID(HttpStatus.INTERNAL_SERVER_ERROR, ClientExceptionCode.NO_SESSION_ID, "웹소켓 subscribe 요청에 sessionId가 없음."),
 
     // 한 줄 일기
-    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.DIARY_NOT_FOUND, "해당되는 일기가 존재하지 않습니다.");
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.DIARY_NOT_FOUND, "해당되는 일기가 존재하지 않습니다."),
+
+    // 스포티파이 리이슈
+    SPOTIFY_REISSUE_ERROR(HttpStatus.UNAUTHORIZED, ClientExceptionCode.SPOTIFY_REISSUE_ERROR, "스포티파이 토큰 리이슈에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final ClientExceptionCode clientExceptionCode;

--- a/mavve/src/main/java/com/efub/mavve/songs/service/SongService.java
+++ b/mavve/src/main/java/com/efub/mavve/songs/service/SongService.java
@@ -32,13 +32,13 @@ public class SongService {
         Long userId = user.getUserId();
         log.info("userId - {} is searching : {}", userId, query);
 
-        // TODO: 스포티파이의 리프레시 토큰에 대한 리이슈 적용 필요 (현재는 1시간 후면 종료)
 
         // 스포티파이 액세스 토큰을 redis에서 가져옴
         String accessToken = spotifyTokenService.getAccessToken(userId.toString());
+        String refreshToken = spotifyTokenService.getRefreshToken(userId.toString());
 
         // 스포티파이 api를 통해 노래 검색
-        SearchSongResponse searchSongResponse =  spotifyClient.getSongSearchResult(query, accessToken, size, page);
+        SearchSongResponse searchSongResponse =  spotifyClient.getSongSearchResult(query, refreshToken, accessToken, size, page, userId.toString());
 
         // 응답 DTO로 변환
         int totalElements = searchSongResponse.getTracks().getTotal();

--- a/mavve/src/main/java/com/efub/mavve/songs/service/SongShareService.java
+++ b/mavve/src/main/java/com/efub/mavve/songs/service/SongShareService.java
@@ -51,7 +51,8 @@ public class SongShareService {
     public Song saveSongBySpotifySongId(String spotifySongId, User user) {
         String userId = user.getUserId().toString();
         String accessToken = spotifyTokenService.getAccessToken(userId);
-        SongInfoResponse songInfoResponse = spotifyClient.getSongInfo(spotifySongId, accessToken);
+        String refreshToken = spotifyTokenService.getRefreshToken(userId);
+        SongInfoResponse songInfoResponse = spotifyClient.getSongInfo(spotifySongId, accessToken, refreshToken, userId);
         Song newSong = Song.fromSongInfoResponse(songInfoResponse);
         saveSong(newSong);
         List<Artist> artists = artistService.findOrCreateArtists(songInfoResponse.getArtists());

--- a/mavve/src/main/java/com/efub/mavve/songs/service/spotify/SpotifyClient.java
+++ b/mavve/src/main/java/com/efub/mavve/songs/service/spotify/SpotifyClient.java
@@ -1,5 +1,7 @@
 package com.efub.mavve.songs.service.spotify;
 
+import com.efub.mavve.auth.service.jwt.SpotifyTokenService;
+import com.efub.mavve.auth.service.oauth.OauthClient;
 import com.efub.mavve.global.exception.ExceptionCode;
 import com.efub.mavve.global.exception.MavveException;
 import com.efub.mavve.songs.dto.response.spotify.SearchSongResponse;
@@ -7,7 +9,10 @@ import com.efub.mavve.songs.dto.response.spotify.SongInfoResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
+
+import java.util.function.Function;
 
 @Slf4j
 @Component
@@ -17,29 +22,49 @@ public class SpotifyClient {
     private final SpotifyProperties spotifyProperties;
     private final String headerName = "Authorization";
     private final String headerValue = "Bearer ";
+    private final OauthClient oauthClient;
+    private final SpotifyTokenService spotifyTokenService;
 
-    public SearchSongResponse getSongSearchResult(String query, String accessToken, int limit, int offset) {
-        String searchRequestUri = spotifyProperties.getSerchSongRequestUri(query, limit, offset);
-        return restClient.get()
-                .uri(searchRequestUri)
-                .header(headerName, headerValue + accessToken)
-                .retrieve()
-                // TODO: spotify reissue 로직 추가
-                .body(SearchSongResponse.class);
+    public SearchSongResponse getSongSearchResult(String query, String refreshToken, String accessToken, int limit, int offset, String userId) {
+        return executeWithRetry((token) -> {
+            String searchRequestUri = spotifyProperties.getSerchSongRequestUri(query, limit, offset);
+            return restClient.get()
+                    .uri(searchRequestUri)
+                    .header(headerName, headerValue + token)
+                    .retrieve()
+                    .body(SearchSongResponse.class);
+        }, refreshToken, accessToken, userId, false);
     }
 
-    public SongInfoResponse getSongInfo(String spotifySongId, String accessToken){
-        String songInfoRequestUri = spotifyProperties.getSongInfoRequestUri(spotifySongId);
-        SongInfoResponse songInfoResponse = restClient.get()
-                .uri(songInfoRequestUri)
-                .header(headerName, headerValue + accessToken)
-                .retrieve()
-                // TODO: spotify reissue 로직 추가
-                .body(SongInfoResponse.class);
-        if(songInfoResponse.getName() == null){
-            throw new MavveException(ExceptionCode.SONG_RESULT_NOT_FOUND);
+    public SongInfoResponse getSongInfo(String spotifySongId, String refreshToken, String accessToken, String userId) {
+        return executeWithRetry((token) -> {
+            String songInfoRequestUri = spotifyProperties.getSongInfoRequestUri(spotifySongId);
+            SongInfoResponse songInfoResponse = restClient.get()
+                    .uri(songInfoRequestUri)
+                    .header(headerName, headerValue + accessToken)
+                    .retrieve()
+                    .body(SongInfoResponse.class);
+            if(songInfoResponse.getName() == null){
+                throw new MavveException(ExceptionCode.SONG_RESULT_NOT_FOUND);
+            }
+            return songInfoResponse;
+        }, refreshToken, accessToken, userId, false);
+
+    }
+
+
+    private <T> T executeWithRetry(Function<String, T> requestFunction, String refreshToken, String accessToken, String userId, boolean hasRetried) {
+        try {
+            return requestFunction.apply(accessToken);
+        } catch (HttpClientErrorException.Unauthorized e){
+            if(!hasRetried){
+                String newAccessToken = oauthClient.getReissueResponse(refreshToken).getAccess_token();
+                spotifyTokenService.saveAccessToken(userId, newAccessToken);
+                return executeWithRetry(requestFunction, refreshToken, newAccessToken, userId, true);
+            } else {
+                throw new MavveException(ExceptionCode.SPOTIFY_REISSUE_ERROR);
+            }
         }
-        return songInfoResponse;
     }
 
 

--- a/mavve/src/main/resources/application.yml
+++ b/mavve/src/main/resources/application.yml
@@ -42,12 +42,13 @@ cloud:
 spotify:
   client-id: ${CLIENT_ID}
   client-secret: ${CLIENT_SECRET}
-  redirect-uri: http://127.0.0.1:8080/login/oauth2/code/spotify
+  redirect-uri: http://127.0.0.1:5173/login/load
   auth-uri: https://accounts.spotify.com/authorize
   token-uri: https://accounts.spotify.com/api/token
   user-info-uri: https://api.spotify.com/v1/me
   search-uri: https://api.spotify.com/v1/search
   get-track-uri: https://api.spotify.com/v1/tracks
+  reissue-uri: https://accounts.spotify.com/api/token
 server:
   tomcat:
     uri-encoding: UTF-8


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요. 
- 스포티파이 토큰 관련 reissue 진행

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [X] Postman 테스트
- [ ] 단위 테스트 수행

## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요.
### api 두 번 호출해야 reissue되는 문제
문제상황
- spotify access token이 필요한 상황에서 `executedWithRetry()`를 통해 동시에 리이슈 처리를 하고자 했습니다.
- 이 과정에서 해당 메서드에서 사용된 `requestFunction`의 경우에는 accessToken을 캡처하기 때문에 **동적으로 값을 변경할 수 없다는 문제**가 있었습니다.
```
executeWithRetry(() -> {
    // 이 안의 accessToken은 초기 값으로 고정되었습니다.
   
}, {생략...});

```
- 즉, retry해서 새로운 accessToken을 받아와도 만료된 accessToken을 기억하고 이것을 계속 사용하기 때문에 401 error가 떴습니다.

해결방법
- 새로운 토큰을 받아오기 위해서 Function<String, T> 형태로 바꾸어 accessToken 자체를 주입하여 가져오는 방식으로 구조를 변경하였더니 문제가 해결되었습니다.
 


## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- closes #19 
