### PR TITLE
[Fix] 방 비웠다가 바로 다시 입장한 경우 다음 노래 전달 중복 에러 수정

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/room/service/RoomService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/RoomService.java
@@ -176,7 +176,8 @@ public class RoomService {
 
     // 첫 입장자인 경우 처리
     private CurrentSongSummary handleFirstEnter(Long roomId) {
-        if (!roomUserRedisService.hasUsers(roomId)) {
+        // 입장자 없음 + 현재 저장되어 있는 노래가 없는 경우 첫 노래부터 재생 시작
+        if (!roomUserRedisService.hasUsers(roomId) && !roomSongRedisService.hasCurrentSong(roomId)) {
             // 방 생성된 뒤 플레이리스트의 노래들 redis에 저장
             if(!roomSongRedisService.hasSongs(roomId)){
                 roomPlaylistService.addSongsByPlaylist(roomId);

--- a/mavve/src/main/java/com/efub/mavve/room/service/redis/RoomSongRedisService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/redis/RoomSongRedisService.java
@@ -68,6 +68,14 @@ public class RoomSongRedisService {
         return result;
     }
 
+    // 현재 노래 리스트 있는지 확인
+    public boolean hasSongs(Long roomCode){
+        String key = RoomRedisKeyUtils.getSongListKey(roomCode);
+        Long songCount = objectRedisTemplate.opsForList().size(key);
+
+        return !(songCount == 0 || songCount == null);
+    }
+
     // 노래 리스트 삭제
     public void deleteSongs(Long roomCode, List<String> songIdsToRemove) {
         try{
@@ -125,14 +133,17 @@ public class RoomSongRedisService {
 
         return CurrentSongSummary.from(song, startTime);
     }
-    
-    // 현재 노래 리스트 있는지 확인
-    public boolean hasSongs(Long roomCode){
-        String key = RoomRedisKeyUtils.getSongListKey(roomCode);
-        Long songCount = objectRedisTemplate.opsForList().size(key);
-        log.info("no song in redis");
 
-        return !(songCount == 0 || songCount == null);
+    // 현재 재생되고 있는 노래 있는지 확인
+    public boolean hasCurrentSong(Long roomCode) {
+        String key = RoomRedisKeyUtils.getCurrentSongKey(roomCode);
+        return objectRedisTemplate.opsForHash().hasKey(key, "song");
+    }
+
+    // 현재 재생되고 있는 노래 삭제
+    public void deleteCurrentSong(Long roomCode){
+        String key = RoomRedisKeyUtils.getCurrentSongKey(roomCode);
+        objectRedisTemplate.delete(key);
     }
 
     // 노래 id용 UUID값 생성

--- a/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/websocket/RoomSongWebsocketService.java
@@ -61,7 +61,7 @@ public class RoomSongWebsocketService {
         taskScheduler.schedule(() -> {
             // 방에 사용자 있는지 확인하고 스케쥴링
             if(!userRedisService.hasUsers(roomCode)){
-                log.info("no user! stop scheduling");
+                songRedisService.deleteCurrentSong(roomCode);
                 return;
             }
             SongRedis nextSong = songRedisService.getNextSong(roomCode, currentSong);


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요.
- 방을 비운 후에 바로 다시 입장을 하면 기존 다음 노래 예약이 취소되지 않은 채 또 다음 노래 예약을 하여 중복되는 에러를 수정함.

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행

## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- closes #101
