### PR TITLE
[Fix] 이전채팅 불러올 때 id 기준이 아닌 createdAt 기준으로 변경

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/global/exception/ClientExceptionCode.java
+++ b/mavve/src/main/java/com/efub/mavve/global/exception/ClientExceptionCode.java
@@ -38,4 +38,5 @@ public enum ClientExceptionCode {
     NO_SESSION_ID,
 
     SPOTIFY_REISSUE_ERROR,
+    CHAT_NOT_FOUND,
 }

--- a/mavve/src/main/java/com/efub/mavve/global/exception/ExceptionCode.java
+++ b/mavve/src/main/java/com/efub/mavve/global/exception/ExceptionCode.java
@@ -51,6 +51,9 @@ public enum ExceptionCode {
     //방
     ROOM_OWNER_MISMATCH(HttpStatus.UNAUTHORIZED, ClientExceptionCode.ROOM_OWNER_MISMATCH, "방에 대한 권한이 없습니다."),
 
+    //채팅
+    CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.CHAT_NOT_FOUND, "해당 id의 채팅이 존재하지 않습니다."),
+
     //웹소켓
     NO_SESSION_ID(HttpStatus.INTERNAL_SERVER_ERROR, ClientExceptionCode.NO_SESSION_ID, "웹소켓 subscribe 요청에 sessionId가 없음."),
 

--- a/mavve/src/main/java/com/efub/mavve/room/repository/RoomChatRepository.java
+++ b/mavve/src/main/java/com/efub/mavve/room/repository/RoomChatRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RoomChatRepository extends JpaRepository<RoomChat, Long> {
@@ -15,8 +16,8 @@ public interface RoomChatRepository extends JpaRepository<RoomChat, Long> {
             FROM RoomChat c 
             JOIN c.user u 
             WHERE c.room.roomId = :roomId 
-            AND (:lastChatId is NULL OR c.createdAt < :lastCreatedAt) 
+            AND (:lastCreatedAt is NULL OR c.createdAt < :lastCreatedAt) 
             ORDER BY c.createdAt DESC
             """)
-    List<ChatSummary> findChatsByRoomId(@Param("roomId") Long roomId, @Param("lastChatId") Long lastChatId, Pageable pageable);
+    List<ChatSummary> findChatsByRoomId(@Param("roomId") Long roomId, @Param("lastCreatedAt") LocalDateTime lastCreatedAt, Pageable pageable);
 }

--- a/mavve/src/main/java/com/efub/mavve/room/service/RoomChatService.java
+++ b/mavve/src/main/java/com/efub/mavve/room/service/RoomChatService.java
@@ -1,6 +1,8 @@
 package com.efub.mavve.room.service;
 
 import com.efub.mavve.auth.domain.User;
+import com.efub.mavve.global.exception.ExceptionCode;
+import com.efub.mavve.global.exception.MavveException;
 import com.efub.mavve.room.domain.Room;
 import com.efub.mavve.room.domain.RoomChat;
 import com.efub.mavve.room.dto.response.ChatListResponse;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -42,9 +45,19 @@ public class RoomChatService {
 
     @Transactional(readOnly = true)
     public ChatListResponse getAllChats(Long roomId, Long lastChatId) {
+        LocalDateTime lastChatCreatedAt = null;
+        if (lastChatId != null) {
+            RoomChat chat = getChatById(lastChatId); // 이건 존재하는지 체크하는 용도
+            lastChatCreatedAt = chat.getCreatedAt();
+        }
         Pageable pageable = PageRequest.of(0, CHATLIST_SIZE);
-        List<ChatSummary> chatList = roomChatRepository.findChatsByRoomId(roomId, lastChatId, pageable);
+        List<ChatSummary> chatList = roomChatRepository.findChatsByRoomId(roomId, lastChatCreatedAt, pageable);
         Collections.reverse(chatList);
         return new ChatListResponse(chatList);
+    }
+
+    private RoomChat getChatById(Long roomId){
+        return roomChatRepository.findById(roomId)
+                .orElseThrow(() -> new MavveException(ExceptionCode.CHAT_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요. 
- 이전채팅 불러올 때 id 기준이 아닌 createdAt 기준으로 변경

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행

## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- #94
