### PR TITLE
[Fix] 로그인 필요한 api에 빈 헤더로 요청 시 에러처리

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/auth/service/jwt/JwtAuthenticationFilter.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/service/jwt/JwtAuthenticationFilter.java
@@ -48,6 +48,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
 
+            } else{
+               throw new CustomAuthenticationException(
+                       ExceptionCode.AUTH_TOKEN_EMPTY, ExceptionCode.AUTH_TOKEN_EMPTY.getMessage(), null);
             }
             filterChain.doFilter(request, response);
         } catch (AuthenticationException exception){

--- a/mavve/src/main/java/com/efub/mavve/global/config/CustomAuthenticationEntryPoint.java
+++ b/mavve/src/main/java/com/efub/mavve/global/config/CustomAuthenticationEntryPoint.java
@@ -40,6 +40,8 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         );
 
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
         response.setContentType("application/json;charset=UTF-8");
         objectMapper.writeValue(response.getWriter(), responseBody);
     }

--- a/mavve/src/main/java/com/efub/mavve/global/config/SecurityConfig.java
+++ b/mavve/src/main/java/com/efub/mavve/global/config/SecurityConfig.java
@@ -29,7 +29,23 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/**").permitAll() // 추후 변경 예정
+                        auth.requestMatchers(
+//                                        "/**"
+                                // TODO: http 메서드 별로 변경 필요
+                                        "/auth/redirect/**",
+                                        "/auth/login",
+                                        "/rooms",
+                                        "/rooms/*/enter",
+                                        "/rooms/*/chats/**",
+                                        "/rooms/hot",
+                                        "/rooms/like",
+                                        "/rooms/*/playlists",
+                                        "/diaries",
+                                        "/playlists/search/**",
+                                        "/image/**",
+                                        "/pub/**",
+                                        "/topic/**"
+                                ).permitAll()
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요. 
- 빈 헤더로 로그인이 필요한 api에 요청하게 되면 500이 떠서 401이 뜨도록 변경했습니다!

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [X] Postman 테스트
- [ ] 단위 테스트 수행


## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- closes #109 
