### PR TITLE
Fix: spotifySongId로 플레이리스트 안 노래 삭제

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/playlist/controller/PlaylistController.java
+++ b/mavve/src/main/java/com/efub/mavve/playlist/controller/PlaylistController.java
@@ -89,11 +89,11 @@ public class PlaylistController {
     }
 
     // 플레이리스트에 노래 삭제
-    @DeleteMapping("/{playlistId}/songs/{songId}")
+    @DeleteMapping("/{playlistId}/songs/{spotifySongId}")
     public ResponseEntity<Void> deleteSongInPlaylist(@AuthenticationPrincipal User user,
                                                  @PathVariable("playlistId") Long playlistId,
-                                                 @PathVariable("songId") Long songId){
-        playlistService.deleteSongInPlaylist(user, playlistId, songId);
+                                                 @PathVariable("spotifySongId") String spotifySongId){
+        playlistService.deleteSongInPlaylist(user, playlistId, spotifySongId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/mavve/src/main/java/com/efub/mavve/playlist/domain/Playlist.java
+++ b/mavve/src/main/java/com/efub/mavve/playlist/domain/Playlist.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.sql.SQLOutput;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +37,7 @@ public class Playlist {
 
     private String playImageUrl;
 
-    @OneToMany(mappedBy = "playlist", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "playlist", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlaylistSong> playlistSongs = new ArrayList<>();
 
     @CreatedDate

--- a/mavve/src/main/java/com/efub/mavve/playlist/service/PlaylistService.java
+++ b/mavve/src/main/java/com/efub/mavve/playlist/service/PlaylistService.java
@@ -16,6 +16,7 @@ import com.efub.mavve.songs.domain.Song;
 import com.efub.mavve.songs.dto.response.SongResponse;
 import com.efub.mavve.songs.service.SongShareService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,7 @@ import static com.efub.mavve.songs.service.spotify.SearchType.playlist;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PlaylistService {
 
     private final PlaylistRepository playlistRepository;
@@ -117,10 +119,10 @@ public class PlaylistService {
     }
 
     @Transactional
-    public void deleteSongInPlaylist(User user, Long playlistId, Long songId) {
+    public void deleteSongInPlaylist(User user, Long playlistId, String spotifySongId) {
         Playlist playlist = getPlaylistOrThrow(playlistId);
         validatePlaylistOwner(playlist, user);
-        Song song = songShareService.getSongBySongId(songId);
+        Song song = songShareService.getSongBySpotifySongId(spotifySongId);
         PlaylistSong target = playlistSongService.getPlaylistSongByPlaylistAndSong(playlist, song);
         playlist.removeSong(song, target);
     }


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요. 
- 기존에 db에서 자동으로 생성하는 songId로 노래 삭제를 했는데 spotifySongId로 삭제하는 것으로 바꾸었습니다.

## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  
- [X] Postman 테스트
- [ ] 단위 테스트 수행


## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.
- closes #118 
