### PR TITLE
[Fix] cors 허용 도메인 변경

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/global/config/CorsConfig.java
+++ b/mavve/src/main/java/com/efub/mavve/global/config/CorsConfig.java
@@ -13,7 +13,7 @@ public class CorsConfig {
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedOriginPatterns(List.of("http://127.0.0.1:5173"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.addAllowedHeader("*");
         configuration.addExposedHeader("Location");


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요.
- 쿠키 관련해서 cors 관련 설정을 변경하여 http://127.0.0.1:5173 만 허용하게 했습니다.
- 추후에 배포된 도메인도 추가할 예정입니다

