### PR TITLE
[Fix] 로그아웃 시 refresh 토큰 파라미터 삭제

### DIFF
--- a/mavve/src/main/java/com/efub/mavve/auth/controller/AuthController.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/controller/AuthController.java
@@ -30,9 +30,8 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@AuthenticationPrincipal User user,
                                        HttpServletResponse response,
-                                       @RequestHeader("Authorization") String accessToken,
-                                       @CookieValue(value = "refresh_token", required = true) String refreshToken) {
-        authService.logout(user, accessToken, response, refreshToken);
+                                       @RequestHeader("Authorization") String accessToken) {
+        authService.logout(user, accessToken, response);
         return ResponseEntity.ok().build();
     }
 

--- a/mavve/src/main/java/com/efub/mavve/auth/service/AuthService.java
+++ b/mavve/src/main/java/com/efub/mavve/auth/service/AuthService.java
@@ -71,13 +71,13 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(User user, String accessToken, HttpServletResponse response, String refreshToken) {
+    public void logout(User user, String accessToken, HttpServletResponse response) {
         refreshTokenService.deleteRefreshToken(user.getUserId().toString());
         String originAccessToken = accessToken.substring(7);
         long remainingTime = jwtResolver.getRemainingTime(originAccessToken);
         tokenService.registerBlackList(originAccessToken, remainingTime);
 
-        Cookie cookie = new Cookie("refreshToken", null);
+        Cookie cookie = new Cookie("refresh_token", null);
         cookie.setMaxAge(0);
         cookie.setPath("/");
         cookie.setHttpOnly(true);


### PR DESCRIPTION


## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요
- 로그아웃 시 프론트에서 400 에러가 나는 상황 방지를 위해서 파라미터에서 refresh token을 제외하는 테스트 시행
